### PR TITLE
feat: Enable autopublishing for Slurm snap CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Slurm snap tests
+name: CI
 on:
   workflow_call:
   pull_request:

--- a/.github/workflows/promote-to-stable.yaml
+++ b/.github/workflows/promote-to-stable.yaml
@@ -1,0 +1,38 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Promote
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+
+jobs:
+  promote:
+    name: ⬆️ Promote to stable
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    if: |
+      ( !github.event.issue.pull_request )
+      && contains(github.event.comment.body, '/promote ')
+      && contains(github.event.*.labels.*.name, 'testing')
+    steps:
+      - name: ⬆️ Promote to stable
+        uses: snapcrafters/ci/promote-to-stable@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE_STABLE }} # Expires October 30th, 2024

--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -1,0 +1,72 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+on:
+  # Run the workflow each time new commits are pushed to the main branch.
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  get-architectures:
+    name: 🖥 Get snap architectures
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.get-architectures.outputs.architectures }}
+      architectures-list: ${{ steps.get-architectures.outputs.architectures-list }}
+    steps:
+      - name: 🖥 Get snap architectures
+        id: get-architectures
+        uses: snapcrafters/ci/get-architectures@main
+
+  release:
+    name: 🚢 Release to latest/candidate
+    needs: get-architectures
+    runs-on: ubuntu-latest
+    environment: "Candidate Branch"
+    strategy:
+      matrix:
+        architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
+    steps:
+      - name: 🚢 Release to latest/candidate
+        uses: snapcrafters/ci/release-to-candidate@main
+        with:
+          architecture: ${{ matrix.architecture }}
+          launchpad-token: ${{ secrets.LP_BUILD }}
+          store-token: ${{ secrets.SNAP_STORE_CANDIDATE }} # Expires October 30th, 2024
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  call-for-testing:
+    name: 📣 Create call for testing
+    needs: [release, get-architectures]
+    environment: "Candidate Branch"
+    runs-on: ubuntu-latest
+    outputs:
+      issue-number: ${{ steps.issue.outputs.issue-number }}
+    steps:
+      - name: 📣 Create call for testing
+        id: issue
+        uses: snapcrafters/ci/call-for-testing@main
+        with:
+          architectures: ${{ needs.get-architectures.outputs.architectures }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,11 @@ website: "https://slurm.schedmd.com"
 base: core24
 confinement: classic
 compression: lzo
+platforms:
+  amd64:
+  arm64:
+  ppc64el:
+  s390x:
 environment:
   # Need this PATH declaration so that the Python-based
   # snap hooks can find the embedded Python interpreter with


### PR DESCRIPTION
This pull request adds auto-publishing for the Slurm snap by using the Launchpad CI builders to build multiple versions of the Slurm snap. It also adds the ability to automatically update the Slurm snap via issue comments.

Key things:

1. Adds the `release-to-candidate` action
2. Adds the `promote-to-stable` action
3. Declare platforms using the platforms keywords.
  a. `armhf` support is excluded because Slurm dropped support for 32-bit architectures. We can still build, but our own risk, so let's not until we have clearly defined use case.
  b. `riscv64` support is excluded due to unknown build failures within the Launchpad builders. Will need to manually debug in a local `riscv64` builder to understand what the issue is with snapcraft.