### PR TITLE
feat: Add Ubuntu HPC bot as publisher

### DIFF
--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -55,6 +55,8 @@ jobs:
           launchpad-token: ${{ secrets.LP_BUILD }}
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }} # Expires October 30th, 2024
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          bot-name: "Ubuntu HPC Bot"
+          bot-email: "nuccitheboss+ubuntuhpcbot@ubuntu.com"
 
   call-for-testing:
     name: 📣 Create call for testing


### PR DESCRIPTION
Updated CI action so that we can set a custom publisher rather than be required to use the `Snapcrafters Bot` account to tag releases + sync upstream versions of code: https://github.com/snapcrafters/ci/pull/40

When new candidate versions of the slurm snap are published, a tag for each architecture + revision will be created by the Ubuntu HPC bot account.

Ubuntu HPC bot account can be located here: https://github.com/ubuntu-hpc-bot. I've invited the Ubuntu HPC bot as a member to the Ubuntu HPC organization.