### PR TITLE
fix: Use HPC bot token rather than GitHub token

### DIFF
--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -54,7 +54,7 @@ jobs:
           architecture: ${{ matrix.architecture }}
           launchpad-token: ${{ secrets.LP_BUILD }}
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }} # Expires October 30th, 2024
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.UBUNTU_HPC_BOT_TOKEN }} # Expires October 30th, 2024
           bot-name: "Ubuntu HPC Bot"
           bot-email: "nuccitheboss+ubuntuhpcbot@ubuntu.com"
 


### PR DESCRIPTION
Fixes issue with creating a new release tag after the Slurm snap has been successfully built. We need to use a PAT for the ubuntu-hpc-bot account rather than the GitHub token.

This should fix our issue with creating new tags for our releases!