### PR TITLE
fix: point the munged wrapper to the correct binary path

### DIFF
--- a/overlays/sbin/munged.wrapper
+++ b/overlays/sbin/munged.wrapper
@@ -17,7 +17,7 @@
 . "${SNAP_COMMON}/.env"
 
 # Start munge authentication services.
-"${SNAP}"/usr/sbin/munged \
+"${SNAP}"/sbin/munged \
   --key-file "${SNAP_COMMON}/etc/munge/munge.key" \
   --socket "${SNAP_COMMON}/run/munge/munged.socket.2" \
   --pid-file "${SNAP_COMMON}/run/munge/munged.pid" \


### PR DESCRIPTION
With the new changes, the munged binary now lives on `sbin`.