### PR TITLE
fix: make the prometheus exporter use the cli fallback parsing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,7 @@ apps:
     install-mode: disable
     after: [munged]
   slurm-prometheus-exporter:
-    command: bin/prometheus-slurm-exporter
+    command: bin/prometheus-slurm-exporter -slurm.cli-fallback
     daemon: simple
     install-mode: disable
     after: [munged]


### PR DESCRIPTION
Since Slurm changed the output of its json format between versions, the exporter breaks while trying to parse the new format. The `-slurm.cli-fallback` option allows the exporter to pass a custom output format through the `--format` option, which should be more resilient against breaking changes.