### PR TITLE
fix: remove slurm.conf location override from env

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,6 @@ environment:
   # the necessary dependencies packaged in `site-packages`.
   # yamllint disable-line rule:line-length
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
-  SLURM_CONF: $SNAP_COMMON/etc/slurm/slurm.conf
 
 apps:
   logrotate:


### PR DESCRIPTION
The patch to `src/common/Makefile.am` sets the default location for slurm.conf to $SNAP_COMMON/etc/slurm/slurm.conf. Having this environment variable around messes with the CLI commands when running in configless mode as these commands will still look for slurm.conf in $SNAP_COMMON/etc/slurm/slurm.conf. Rather than under /var/spool.

Note that you will possibly need to set `SlurmdSpoolDir` for the CLI commands to locate the cached slurm.conf when running in configless mode. This option should be set in the main slurm controller.

### Misc.

You can use the following command to set the slurmd spool directory on the main slurm controller node (slurmctld):

`snap set slurm slurm.slurmd-spool-dir=/var/snap/slurm/common/var/lib`

Ideally this will be automatically set at installation once we have the fix for #19 