### PR TITLE
fix: remove duplicate `hdf5-helpers`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -235,7 +235,6 @@ parts:
       - libhwloc15
       - librrd8
       - libipmimonitoring6
-      - hdf5-helpers
       - libfreeipmi17
       - hdf5-helpers
       - man2html


### PR DESCRIPTION
Causes build to break in CI pipeline, but not locally :thinking: