### PR TITLE
fix: remove duplicate `libpam0g-dev`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -202,7 +202,6 @@ parts:
       - default-libmysqlclient-dev
       - libpam0g-dev
       - libperl-dev
-      - libpam0g-dev
       - liblua5.4-dev
       - libhwloc-dev
       - librrd-dev


### PR DESCRIPTION
Why must you do this to me `snapcraft`?