### PR TITLE
fix: do not preseed slurm and slurmdbd configuration files

### DIFF
--- a/src/slurmhelpers/hooks.py
+++ b/src/slurmhelpers/hooks.py
@@ -89,9 +89,7 @@ def install(snap: Snap) -> None:
     """
     setup_logging(snap.paths.common / "hooks.log")
     munge = Munge(snap)
-    slurm = Slurm(snap)
     slurmd = Slurmd(snap)
-    slurmdbd = Slurmdbd(snap)
     slurmrestd = Slurmrestd(snap)
 
     logging.info("Executing snap `install` hook.")
@@ -106,12 +104,6 @@ def install(snap: Snap) -> None:
 
     logging.info("Generating default munge.key secret.")
     munge.generate_key()
-
-    logging.info("Creating empty `slurm.conf` file.")
-    slurm.config_file.touch(0o644)
-
-    logging.info("Creating empty `slurmdbd.conf` file.")
-    slurmdbd.config_file.touch(0o644)
 
 
 def configure(snap: Snap) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,6 +28,7 @@ def fake_fs(fs):
     """Mock filesystem for configuration hook unit tests."""
     yield fs
 
+
 @pytest.fixture
 def env():
     """Mock the snap runtime environment."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,6 +24,11 @@ from snaphelpers._ctl import ServiceInfo
 
 
 @pytest.fixture
+def fake_fs(fs):
+    """Mock filesystem for configuration hook unit tests."""
+    yield fs
+
+@pytest.fixture
 def env():
     """Mock the snap runtime environment."""
     yield {

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -143,7 +143,7 @@ class TestMungeModel:
 class TestSlurmModel:
     """Test the `Slurm` data model."""
 
-    def test_update_config(self, mocker, slurm) -> None:
+    def test_update_config(self, mocker, fake_fs, slurm) -> None:
         """Test `update_config` method."""
         nodes = NodeMap()
         frontend_nodes = FrontendNodeMap()
@@ -160,9 +160,11 @@ class TestSlurmModel:
         config.node_sets = node_sets
         config.partitions = partitions
 
+        # Create fake file for slurm configuration editor.
+        fake_fs.create_file("/var/snap/slurm/common/etc/slurm/slurm.conf")
+
         # Test when there has been no change to slurm configuration.
         mocker.patch("slurmutils.editors.slurmconfig.load", return_value=config)
-        mocker.patch("slurmutils.editors.slurmconfig.dump")
         mocker.patch("slurmhelpers.models._process_nodes", return_value=nodes)
         mocker.patch("slurmhelpers.models._process_frontend_nodes", return_value=frontend_nodes)
         mocker.patch("slurmhelpers.models._process_down_nodes", return_value=down_nodes)
@@ -183,7 +185,6 @@ class TestSlurmModel:
 
         # Test when there has been a change made to the slurm configuration.
         mocker.patch("slurmutils.editors.slurmconfig.load", return_value=config)
-        mocker.patch("slurmutils.editors.slurmconfig.dump")
         mocker.patch("slurmhelpers.models._process_nodes", return_value=nodes)
         mocker.patch("slurmhelpers.models._process_frontend_nodes", return_value=frontend_nodes)
         mocker.patch("slurmhelpers.models._process_down_nodes", return_value=down_nodes)
@@ -204,7 +205,6 @@ class TestSlurmModel:
 
         # Test when a bad slurmdbd configuration option has been provided.
         mocker.patch("slurmutils.editors.slurmconfig.load", return_value=config)
-        mocker.patch("slurmutils.editors.slurmconfig.dump")
         mocker.patch("slurmhelpers.models._process_nodes", return_value=nodes)
         mocker.patch("slurmhelpers.models._process_frontend_nodes", return_value=frontend_nodes)
         mocker.patch("slurmhelpers.models._process_down_nodes", return_value=down_nodes)
@@ -407,12 +407,15 @@ class TestSlurmdModel:
 class TestSlurmdbdModel:
     """Test the `Slurmdbd` data model."""
 
-    def test_update_config(self, mocker, slurmdbd) -> None:
+    def test_update_config(self, mocker, fake_fs, slurmdbd) -> None:
         """Test `update_config` method."""
         config = SlurmdbdConfig()
         config.log_file = "/var/log/slurm/slurmdbd.log"
         config.private_data = ["accounts", "events", "jobs"]
         config.track_slurmctld_down = "no"
+
+        # Create fake file for slurmdbd configuration editor.
+        fake_fs.create_file("/var/snap/slurm/common/etc/slurm/slurmdbd.conf")
 
         # Test when there has been no change to slurmdbd configuration.
         mocker.patch("slurmutils.editors.slurmdbdconfig.load", return_value=config)
@@ -427,7 +430,6 @@ class TestSlurmdbdModel:
 
         # Test when there has been a change to the slurmdbd configuration.
         mocker.patch("slurmutils.editors.slurmdbdconfig.load", return_value=config)
-        mocker.patch("slurmutils.editors.slurmdbdconfig.dump")
         slurmdbd.update_config(
             {
                 "log-file": "/var/log/slurm/slurmdbd.log",
@@ -438,7 +440,6 @@ class TestSlurmdbdModel:
 
         # Test when a bad slurmdbd configuration option has been provided.
         mocker.patch("slurmutils.editors.slurmdbdconfig.load", return_value=config)
-        mocker.patch("slurmutils.editors.slurmdbdconfig.dump")
         with pytest.raises(AttributeError):
             slurmdbd.update_config(
                 {

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ description = Run unit tests.
 deps =
     pytest
     pytest-mock
+    pyfakefs
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
This pull request removes preseeding an empty _slurm.conf_ and _slurmdbd.conf_ configuration file in the install hook. The _slurm.conf_ file, specifically, would conflict with the _slurm.conf_ file fetched from the Slurm controller `slurmctld`. This caused issues if attempting to use slurm CLI commands as they would try to read the preseeded configuration file instead of the _slurm.conf_ file under `conf-cache`.

The configuration hooks now use the context manager provided by `slurmutils` to create the files on demand the first time their respective configuration hook is invoked.

Fixes #27 

### Misc.

* Add `pyfakefs` as test dependency. Context manager don't like being mocked, so I just created a fake file within the virtual filesystem instead :sweat_smile: