### PR TITLE
feat: add the `_daemon_` user for non-privileged services

### DIFF
--- a/overlays/sbin/slurmrestd.wrapper
+++ b/overlays/sbin/slurmrestd.wrapper
@@ -25,8 +25,10 @@ fi
 # Export invalid Slurm JWT token to activate JWT authentication in slurmrestd.
 # See for more details: https://slurm.schedmd.com/rest.html#jwt
 export SLURM_JWT=
-"${SNAP}"/sbin/slurmrestd \
-  -f "${SNAP_COMMON}/etc/slurm/slurm.conf" \
-  --max-connections "${SLURMRESTD_MAX_CONNECTIONS}" \
-  -t "${SLURMRESTD_MAX_THREAD_COUNT}" \
-  "$(hostname -s):6820"
+# Drop to _daemon_ because slurmrestd cannot run as either root or SlurmUser.
+"${SNAP}"/usr/bin/setpriv --clear-groups --reuid _daemon_ --regid _daemon_ -- \
+  "${SNAP}"/sbin/slurmrestd \
+    -f "${SNAP_COMMON}/etc/slurm/slurm.conf" \
+    --max-connections "${SLURMRESTD_MAX_CONNECTIONS}" \
+    -t "${SLURMRESTD_MAX_THREAD_COUNT}" \
+    "$(hostname -s):6820"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,9 @@ environment:
   # yamllint disable-line rule:line-length
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
 
+system-usernames:
+  _daemon_: shared
+
 apps:
   logrotate:
     command: usr/sbin/logrotate $SNAP_COMMON/etc/logrotate/logrotate.conf
@@ -263,6 +266,7 @@ parts:
       - libsz2
       - libhdf5-hl-100
       - libhdf5-103-1
+      - util-linux  # `setpriv`
     override-build: |
       craftctl default
 


### PR DESCRIPTION
Allows running `slurmrestd` using the unprivileged user `_daemon_`.