### PR TITLE
fix: use `snap_daemon` instead of `_daemon_`

### DIFF
--- a/overlays/sbin/slurmrestd.wrapper
+++ b/overlays/sbin/slurmrestd.wrapper
@@ -25,8 +25,8 @@ fi
 # Export invalid Slurm JWT token to activate JWT authentication in slurmrestd.
 # See for more details: https://slurm.schedmd.com/rest.html#jwt
 export SLURM_JWT=
-# Drop to _daemon_ because slurmrestd cannot run as either root or SlurmUser.
-"${SNAP}"/usr/bin/setpriv --clear-groups --reuid _daemon_ --regid _daemon_ -- \
+# Drop to snap_daemon because slurmrestd cannot run as either root or SlurmUser.
+"${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- \
   "${SNAP}"/sbin/slurmrestd \
     -f "${SNAP_COMMON}/etc/slurm/slurm.conf" \
     --max-connections "${SLURMRESTD_MAX_CONNECTIONS}" \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,7 +40,7 @@ environment:
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
 
 system-usernames:
-  _daemon_: shared
+  snap_daemon: shared
 
 apps:
   logrotate:


### PR DESCRIPTION
Apparently the store doesn't support `_daemon_` yet, even if the documentation [recommends using it as a replacement for `snap_daemon`](https://snapcraft.io/docs/system-usernames):

> From snapd 2.61 onwards, `snap_daemon` is being deprecated and replaced with `_daemon_` (with underscores), which now possesses a UID of 584792.

Hence, just fallback to the good ol' `snap_daemon`.