### PR TITLE
fix: rename `slurm-prometheus-exporter` to `prometheus-slurm-exporter` and add args variable

### DIFF
--- a/overlays/sbin/prometheus-slurm-exporter.wrapper
+++ b/overlays/sbin/prometheus-slurm-exporter.wrapper
@@ -1,0 +1,20 @@
+#!/bin/sh  -e
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Load in snap configuration defaults.
+. "${SNAP_COMMON}/.env"
+
+# Start prometheus slurm exporter.
+"${SNAP}"/bin/prometheus-slurm-exporter $PROMETHEUS_SLURM_EXPORTER_ARGS

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,9 +85,8 @@ apps:
     daemon: simple
     install-mode: disable
     after: [munged]
-  slurm-prometheus-exporter:
-    # yamllint disable-line rule:line-length
-    command: bin/prometheus-slurm-exporter -slurm.cli-fallback -slurm.collect-diags
+  prometheus-slurm-exporter:
+    command: sbin/prometheus-slurm-exporter.wrapper
     daemon: simple
     install-mode: disable
     after: [munged]
@@ -306,7 +305,7 @@ parts:
         --with-pmix
       make -j${CRAFT_PARALLEL_BUILD_COUNT} && make install
 
-  slurm-prometheus-exporter:
+  prometheus-slurm-exporter:
     after: [slurm]
     source: "https://github.com/rivosinc/prometheus-slurm-exporter.git"
     source-tag: "v1.4.1"


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Rename the Slurm prometheus exporter to conform with its original name `prometheus-slurm-exporter`, and add the `SLURM_PROMETHEUS_EXPORTER_ARGS` environment variable to be able to configure its arguments.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

This is only a cleanup, doesn't require additional documentation.
